### PR TITLE
Update supported Python versions (3.12+)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           working-directory: ./gpapi-python
-          args: --release --sdist -i python3.12 --features pyo3/extension-module
+          args: --release --sdist -i python3.12 -i python3.13 --features pyo3/extension-module
           manylinux: auto
           before-script-linux: |
             yum install -y openssl-devel pkgconfig


### PR DESCRIPTION
Automatically updated supported Python versions to include only stable 3.12+ releases.